### PR TITLE
Use AGP 7.2.2 and remove `javaHome` configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ buildscript {
 plugins {
     kotlin("multiplatform")
     id("org.jetbrains.compose")
-    id("com.android.application") version "7.4.0-alpha10"
+    id("com.android.application") version "7.2.2"
 }
 
 version = "1.0"
@@ -170,7 +170,6 @@ compose {
                     upgradeUuid = "18159995-d967-4CD2-8885-77BFA97CFA9F"
                 }
             }
-            javaHome = projectDir.resolve("jdk-18").toString()
         }
     }
 


### PR DESCRIPTION
I rolled back the AGP to 7.2.2, removed the JDK 18 configuration, and everything worked great!

---

When someone tries to run the project in IntelliJ, they'll be met with the following error.

```
The project is using an incompatible version (AGP 7.4.0-alpha10) of the Android Gradle plugin. Latest supported version is AGP 7.2.0
See Android Studio & AGP compatibility options
```

If they fix it, they'll get this error.

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':run'.
> A problem occurred starting process 'command '/Users/sal/Development/Tetris/jdk-18/bin/java''
```